### PR TITLE
Update to package.json template for newer devDependencies

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -19,8 +19,8 @@
     }
   ],
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.2.0",
+    "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt-contrib-watch": "~0.2.0"
+    "grunt-contrib-watch": "~0.4.4"
   }
 }


### PR DESCRIPTION
The template was using old versions of `grunt-contrib-jshint` and `grunt-contrib-watch`. Updated it.
