### PR TITLE
Provide module name as folder by default

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -28,7 +28,8 @@ NodeGenerator.prototype.askFor = function askFor() {
 
   var prompts = [{
     name: 'name',
-    message: 'Module Name'
+    message: 'Module Name',
+    default: path.basename(process.cwd())
   }, {
     name: 'description',
     message: 'Description',


### PR DESCRIPTION
In this PR:
- Update `name` to be the working folder name by default

Reasons:
- Most of the time, a project is named after the folder it is in
