### PR TITLE
Add npm-debug.log to gitignore

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+npm-debug.log


### PR DESCRIPTION
Node package authors are likely to want the npm-debug log ignored by git.
