### PR TITLE
Add main field to package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -1,6 +1,7 @@
 {
   "name": "<%= slugname %>",
   "version": "0.0.0",
+  "main": "lib/<%= slugname %>.js",
   "description": "<%= props.description %>",
   "homepage": "<%= props.homepage %>",
   "bugs": "<%= repoUrl %>/issues",


### PR DESCRIPTION
Since the main file is created by the generator it should be put into
the package.json.  Fixes #14
