### PR TITLE
Update yeoman-generator to 0.13.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "yeoman-generator": "~0.12.2"
+    "yeoman-generator": "~0.13.3"
   },
   "devDependencies": {
     "mocha": "~1.12.0"


### PR DESCRIPTION
This fixes the following error when utilizing `yo node`:

```
TypeError: Cannot read property 'bold' of undefined
    at Object.<anonymous> (/usr/local/lib/node_modules/generator-node/node_modules/yeoman-generator/lib/util/common.js:5:56)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/generator-node/node_modules/yeoman-generator/lib/base.js:91:26)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
```
