### PR TITLE
Add grunt installation on Travis before_script hook

### DIFF
--- a/app/templates/travis.yml
+++ b/app/templates/travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - '0.10'
   - '0.8'
+before_script:
+  - npm install -g grunt-cli


### PR DESCRIPTION
This is needed because the tests are run with Grunt since 414e181a4337029870cd3e95183ac0b29e16a129. Otherwise Travis will fail with `grunt: not found`.
