### PR TITLE
Fix safeSlugname regex /-([a-z])/g  => /-([a-zA-Z])/g

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -74,7 +74,7 @@ NodeGenerator.prototype.askFor = function askFor() {
   this.prompt(prompts, function (props) {
     this.slugname = this._.slugify(props.name);
     this.safeSlugname = this.slugname.replace(
-      /-([a-z])/g,
+      /-([a-zA-Z])/g,
       function (g) { return g[1].toUpperCase(); }
     );
 


### PR DESCRIPTION
safeSlugname with regex `/-([a-z])/g` will pass error

example: give `angular-Uid` will cause error

So I change the regex to `/-([a-zA-Z])/g`, that's mean `angular-Uid` will pass success to `angularUid`
