### PR TITLE
Fixed boolean options being ignored

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -84,13 +84,11 @@ module.exports = yeoman.generators.Base.extend({
        }, {
          type: 'confirm',
          name: 'cli',
-         message: 'Do you need cli tools?',
-         default: true
+         message: 'Do you need cli tools?'
        }, {
          type: 'confirm',
          name: 'browser',
-         message: 'Do you need browserify?',
-         default: 'true'
+         message: 'Do you need browserify?'
        }];
 
        this.currentYear = (new Date()).getFullYear();


### PR DESCRIPTION
Fixes #68 

Boolean options aren't ignored anymore. 

The only fix was to remove the `default` parameter and let the `choice` prompt type do it's normal job.
