### PR TITLE
Store prompt answers for author fields

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -68,16 +68,20 @@ module.exports = yeoman.generators.Base.extend({
       default: 'MIT'
     }, {
       name: 'githubUsername',
-      message: 'GitHub username'
+      message: 'GitHub username',
+      store: true
     }, {
       name: 'authorName',
-      message: 'Author\'s Name'
+      message: 'Author\'s Name',
+      store: true
     }, {
       name: 'authorEmail',
-      message: 'Author\'s Email'
+      message: 'Author\'s Email',
+      store: true
     }, {
       name: 'authorUrl',
-      message: 'Author\'s Homepage'
+      message: 'Author\'s Homepage',
+      store: true
     }, {
       name: 'keywords',
       message: 'Key your keywords (comma to split)'


### PR DESCRIPTION
Use the prompt store to store these answers:
- GitHub username
- Author's Name
- Author's Email
- Author's Homepage
