### PR TITLE
Add Mocha globals to the jshint globals list

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,5 +13,6 @@
   "quotmark": "single",
   "undef": true,
   "unused": true,
-  "strict": true
+  "strict": true,
+  "mocha" : true
 }

--- a/app/templates/test/test.js
+++ b/app/templates/test/test.js
@@ -1,4 +1,3 @@
-/*global describe, it */
 'use strict';
 var assert = require('assert');
 var <%= safeSlugname %> = require('../');


### PR DESCRIPTION
This will prevent jshint errors when checking the test.js file with jshint. Today doing `grunt` on a newly created repository will result in jshint warnings when checking the test.js file.