### PR TITLE
Add node:gulp subgenerator

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -130,9 +130,6 @@ module.exports = generators.Base.extend({
         email: this.props.authorEmail,
         url: this.props.authorUrl
       },
-      scripts: {
-        test: 'mocha -R spec'
-      },
       files: ['lib'],
       keywords: this.props.keywords
     };
@@ -162,6 +159,10 @@ module.exports = generators.Base.extend({
 
     this.composeWith('node:jscs', {}, {
       local: require.resolve('../jscs')
+    });
+
+    this.composeWith('node:gulp', {}, {
+      local: require.resolve('../gulp')
     });
 
     if (!this.fs.exists(this.destinationPath('README.md'))) {

--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -1,0 +1,74 @@
+'use strict';
+var _ = require('lodash');
+var generators = require('yeoman-generator');
+
+module.exports = generators.Base.extend({
+  constructor: function () {
+    generators.Base.apply(this, arguments);
+
+    this.option('coveralls', {
+      type: Boolean,
+      required: false,
+      defaults: undefined,
+      description: 'Send coverage reports to coveralls'
+    });
+  },
+
+  prompting: function () {
+    this.prompt([{
+      name: 'includeCoveralls',
+      type: 'confirm',
+      message: 'Send coverage reports to coveralls',
+      when: this.options.coveralls == null
+    }], function (props) {
+      this.props = props;
+      if (this.options.coveralls != null) {
+        this.props.includeCoveralls = this.options.coveralls;
+      }
+    }.bind(this));
+  },
+
+  writing: {
+    package: function () {
+      var pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
+
+      // Include Gulp related dev dependencies
+      pkg.devDependencies = pkg.devDependencies || {};
+      _.extend(pkg.devDependencies, {
+        'gulp': '^3.6.0',
+        'gulp-eslint': '^0.8.0',
+        'gulp-istanbul': '^0.8.1',
+        'gulp-jscs': '^1.1.0',
+        'gulp-jshint': '^1.5.3',
+        'gulp-mocha': '^2.0.0',
+        'gulp-plumber': '^1.0.0',
+        'jshint-stylish': '^1.0.0'
+      });
+      if (this.props.includeCoveralls) {
+        pkg.devDependencies['gulp-coveralls'] = '^0.1.0';
+      }
+
+      // Setup testing script
+      pkg.scripts = pkg.scripts || {};
+      pkg.scripts.test = 'gulp';
+
+      this.fs.writeJSON(this.destinationPath('package.json'), pkg);
+    },
+
+    gulpfile: function () {
+      var tasks = ['static', 'test'];
+      if (this.props.includeCoveralls) {
+        tasks.push('coveralls');
+      }
+
+      this.fs.copyTpl(
+        this.templatePath('gulpfile.js'),
+        this.destinationPath('gulpfile.js'),
+        {
+          includeCoveralls: this.props.includeCoveralls,
+          tasks: tasks.join(', ')
+        }
+      );
+    }
+  }
+});

--- a/generators/gulp/templates/gulpfile.js
+++ b/generators/gulp/templates/gulpfile.js
@@ -1,0 +1,56 @@
+'use strict';
+var path = require('path');
+var gulp = require('gulp');
+var mocha = require('gulp-mocha');
+var jshint = require('gulp-jshint');
+var jscs = require('gulp-jscs');
+var istanbul = require('gulp-istanbul');<% if (includeCoveralls) { %>
+var coveralls = require('gulp-coveralls');<% } %>
+var plumber = require('gulp-plumber');
+
+var handleErr = function (err) {
+  console.log(err.message);
+  process.exit(1);
+};
+
+gulp.task('static', function () {
+  return gulp.src('**/*.js')
+    .pipe(jshint('.jshintrc'))
+    .pipe(jshint.reporter('jshint-stylish'))
+    .pipe(jshint.reporter('fail'))
+    .pipe(jscs())
+    .on('error', handleErr);
+});
+
+gulp.task('test', function (cb) {
+  var mochaErr;
+
+  gulp.src(['lib/**/*.js'])
+    .pipe(istanbul({includeUntested: true}))
+    .pipe(istanbul.hookRequire())
+    .on('finish', function () {
+      gulp.src(['test/*.js'])
+        .pipe(plumber())
+        .pipe(mocha({
+          reporter: 'spec'
+        }))
+        .on('error', function (err) {
+          mochaErr = err;
+        })
+        .pipe(istanbul.writeReports())
+        .on('end', function () {
+          cb(mochaErr);
+        });
+    });
+});
+<% if (includeCoveralls) { %>
+gulp.task('coveralls', ['test'], function () {
+  if (!process.env.CI) {
+    return;
+  }
+
+  return gulp.src(path.join(__dirname, 'coverage/lcov.info'))
+    .pipe(coveralls());
+});
+<% } %>
+gulp.task('default', [<%= tasks %>]);

--- a/test/app.js
+++ b/test/app.js
@@ -63,9 +63,6 @@ describe('node:app', function () {
           email: this.answers.authorEmail,
           url: this.answers.authorUrl
         },
-        scripts: {
-          test: 'mocha -R spec'
-        },
         files: ['lib'],
         keywords: this.answers.keywords
       }, null, 2));
@@ -81,9 +78,6 @@ describe('node:app', function () {
         repository: 'yeoman/generator-node',
         license: 'BSD',
         author: 'The Yeoman Team',
-        scripts: {
-          test: 'mocha -R spec'
-        },
         files: ['lib'],
         keywords: ['bar']
       };

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var path = require('path');
+var assert = require('yeoman-generator').assert;
+var helpers = require('yeoman-generator').test;
+
+describe('node:gulp', function () {
+  describe('including coveralls', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../generators/gulp'))
+        .withPrompts({includeCoveralls: true})
+        .on('end', done);
+    });
+
+    it('creates files and configuration', function () {
+      assert.file([
+        'gulpfile.js',
+        'package.json'
+      ]);
+
+      assert.fileContent('gulpfile.js', 'gulp.task(\'coveralls\'');
+      assert.fileContent('gulpfile.js', 'gulp.task(\'test\'');
+      assert.fileContent('gulpfile.js', 'gulp.task(\'static\'');
+
+      assert.fileContent('package.json', 'gulp');
+      assert.fileContent('package.json', 'gulp-coveralls');
+      assert.fileContent('package.json', '"test": "gulp"');
+    });
+  });
+
+  describe('excluding coveralls', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../generators/gulp'))
+        .withPrompts({includeCoveralls: false})
+        .on('end', done);
+    });
+
+    it('does not include coveralls configurations', function () {
+      assert.noFileContent('gulpfile.js', 'gulp.task(\'coveralls\'');
+      assert.noFileContent('package.json', 'gulp-coveralls');
+    });
+  });
+
+  describe('--no-coveralls', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../generators/gulp'))
+        .withOptions({coveralls: false})
+        .on('end', done);
+    });
+
+    it('does not include coveralls configurations', function () {
+      assert.noFileContent('gulpfile.js', 'gulp.task(\'coveralls\'');
+      assert.noFileContent('package.json', 'gulp-coveralls');
+    });
+  });
+
+});


### PR DESCRIPTION
TODO: tests are breaking because we don't have a good way to compare partial JSON. I'll fix this soon enough by adding a method to assert partial JS object match.