### PR TITLE
Add generator-license as dependency

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -82,11 +82,6 @@ module.exports = generators.Base.extend({
         message: 'Project homepage url',
         when: !this.pkg.homepage
       }, {
-        name: 'license',
-        message: 'License',
-        when: !this.pkg.license,
-        default: 'MIT'
-      }, {
         name: 'githubUsername',
         message: 'GitHub username or organization',
         when: !this.pkg.repository
@@ -131,7 +126,6 @@ module.exports = generators.Base.extend({
       description: this.props.description,
       homepage: this.props.homepage,
       repository: this.props.repository,
-      license: this.props.license,
       author: {
         name: this.props.authorName,
         email: this.props.authorEmail,
@@ -180,6 +174,16 @@ module.exports = generators.Base.extend({
       });
     }
 
+    this.composeWith('license', {
+      options: {
+        name: this.props.authorName,
+        email: this.props.authorEmail,
+        website: this.props.authorWebsite
+      }
+    }, {
+      local: require.resolve('generator-license/app')
+    });
+
     if (!this.fs.exists(this.destinationPath('README.md'))) {
       this.composeWith('node:readme', {
         options: {
@@ -187,8 +191,7 @@ module.exports = generators.Base.extend({
           description: this.props.description,
           githubAccount: this.props.githubAccount,
           authorName: this.props.authorName,
-          authorURL: this.props.authorURL,
-          license: this.props.license
+          authorURL: this.props.authorURL
         }
       }, {
         local: require.resolve('../readme')

--- a/generators/readme/index.js
+++ b/generators/readme/index.js
@@ -35,15 +35,10 @@ module.exports = generators.Base.extend({
       required: true,
       description: 'Author url'
     });
-
-    this.option('license', {
-      type: String,
-      required: true,
-      description: 'Project license'
-    });
   },
 
   writing: function () {
+    var pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
     this.fs.copyTpl(
       this.templatePath('README.md'),
       this.destinationPath('README.md'),
@@ -56,7 +51,7 @@ module.exports = generators.Base.extend({
           name: this.options.authorName,
           url: this.options.authorURL
         },
-        license: this.options.license
+        license: pkg.license
       }
     );
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "mocha test -R spec"
   },
   "dependencies": {
+    "generator-license": "^2.0.0",
     "lodash": "^3.7.0",
     "npm-name": "^1.0.2",
     "yeoman-generator": "^0.19.0"

--- a/test/app.js
+++ b/test/app.js
@@ -29,6 +29,11 @@ describe('node:app', function () {
     mockery.registerMock('npm-name', function (name, cb) {
       cb(true);
     });
+
+    mockery.registerMock(
+      require.resolve('generator-license/app'),
+      helpers.createDummyGenerator()
+    );
   });
 
   after(function () {
@@ -41,7 +46,6 @@ describe('node:app', function () {
         name: 'generator-node',
         description: 'A node generator',
         homepage: 'http://yeoman.io',
-        license: 'MIT',
         githubUsername: 'yeoman',
         authorName: 'The Yeoman Team',
         authorEmail: 'hi@yeoman.io',
@@ -75,7 +79,6 @@ describe('node:app', function () {
         description: this.answers.description,
         homepage: this.answers.homepage,
         repository: 'yeoman/generator-node',
-        license: this.answers.license,
         author: {
           name: this.answers.authorName,
           email: this.answers.authorEmail,
@@ -94,7 +97,6 @@ describe('node:app', function () {
         description: 'lots of fun',
         homepage: 'http://yeoman.io',
         repository: 'yeoman/generator-node',
-        license: 'BSD',
         author: 'The Yeoman Team',
         files: ['lib'],
         keywords: ['bar']

--- a/test/readme.js
+++ b/test/readme.js
@@ -3,7 +3,7 @@ var path = require('path');
 var assert = require('yeoman-assert');
 var helpers = require('yeoman-generator').test;
 
-describe('node:travis', function () {
+describe('node:readme', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../generators/readme'))
       .withOptions({
@@ -13,6 +13,11 @@ describe('node:travis', function () {
         authorName: 'Yeoman',
         authorURL: 'http://yeoman.io',
         license: 'MIT'
+      })
+      .on('ready', function (gen) {
+        gen.fs.writeJSON(gen.destinationPath('package.json'), {
+          license: 'MIT'
+        });
       })
       .on('end', done);
   });


### PR DESCRIPTION
Still waiting for https://github.com/jozefizso/generator-license/pull/7 to be merged before updating to a real version.

Also, we should get https://github.com/jozefizso/generator-license/issues/8 fix so we can remove the package.json license field question - in the current state, the question is duplicated.