### PR TITLE
Use absolute paths in generated .gitignore

### DIFF
--- a/generators/git/templates/gitignore
+++ b/generators/git/templates/gitignore
@@ -1,2 +1,2 @@
-node_modules/
-coverage/
+/node_modules/
+/coverage/


### PR DESCRIPTION
The generated .gitignore contains relative paths that will match
in both the root of the project or somewhere down the tree.

This can be problematic if the project gets a folder called `coverage`
or some other ignored name.

This patch makes the default .gitignore absolute.

Triggered by a comment on a similar request for generator-angular:
https://github.com/yeoman/generator-angular/pull/1085#issuecomment-101455837