### PR TITLE
Fix npmName prompt: true/false behaviour reversed

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -69,7 +69,11 @@ module.exports = generators.Base.extend({
           var done = this.async();
 
           npmName(answers.name, function (err, available) {
-            done(available);
+            if (available) {
+              done();
+            } else {
+              done(false);
+            }
           });
         }
       }];


### PR DESCRIPTION
Previously, if a name was available in npm, you would be
reprompted to select a different name. And on the flipside, if a name
was NOT available, the generator would proceed as though it was

Should fix #125 