### PR TITLE
Fix wrong val passed to done when name taken, & a bug in npm-name mock

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -72,7 +72,7 @@ module.exports = generators.Base.extend({
             if (available) {
               done();
             } else {
-              done(true); //re-prompt
+              done(true);
             }
           });
         }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -72,7 +72,7 @@ module.exports = generators.Base.extend({
             if (available) {
               done();
             } else {
-              done(false);
+              done(true); //re-prompt
             }
           });
         }

--- a/test/app.js
+++ b/test/app.js
@@ -27,7 +27,7 @@ describe('node:app', function () {
     mockery.enable({warnOnUnregistered: false});
 
     mockery.registerMock('npm-name', function (name, cb) {
-      cb(null,true);//no errors, name available
+      cb(null, true);
     });
 
     mockery.registerMock(

--- a/test/app.js
+++ b/test/app.js
@@ -27,7 +27,7 @@ describe('node:app', function () {
     mockery.enable({warnOnUnregistered: false});
 
     mockery.registerMock('npm-name', function (name, cb) {
-      cb(true);
+      cb(null,true);//no errors, name available
     });
 
     mockery.registerMock(


### PR DESCRIPTION
This is embarassing - in #125 / #126 I said I was passing `true` to `done(...)` in fact I had set it to false in my fork, but to `true` in the local copy I was using for testing - so in what got merged, we'll continue correctly if the name is not taken in npm, but if the name is taken, it doesn't re-prompt. Corrected that in this PR. Triple-checked I haven't made any silly mistakes again this time :D