### PR TITLE
fix mismatched var names between app and readme

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -101,7 +101,7 @@ module.exports = generators.Base.extend({
         message: 'Project homepage url',
         when: !this.pkg.homepage
       }, {
-        name: 'githubUsername',
+        name: 'githubAccount',
         message: 'GitHub username or organization',
         when: !this.pkg.repository
       }, {
@@ -134,8 +134,8 @@ module.exports = generators.Base.extend({
       this.prompt(prompts, function (props) {
         this.props = _.extend(this.props, props);
 
-        if (props.githubUsername) {
-          this.props.repository = props.githubUsername + '/' + this.props.name;
+        if (props.githubAccount) {
+          this.props.repository = props.githubAccount + '/' + this.props.name;
         }
 
         done();
@@ -238,7 +238,7 @@ module.exports = generators.Base.extend({
           description: this.props.description,
           githubAccount: this.props.githubAccount,
           authorName: this.props.authorName,
-          authorURL: this.props.authorURL,
+          authorUrl: this.props.authorUrl,
           coveralls: this.props.includeCoveralls
         }
       }, {

--- a/generators/readme/index.js
+++ b/generators/readme/index.js
@@ -55,7 +55,7 @@ module.exports = generators.Base.extend({
         githubAccount: this.options.githubAccount,
         author: {
           name: this.options.authorName,
-          url: this.options.authorURL
+          url: this.options.authorUrl
         },
         license: pkg.license,
         includeCoveralls: this.options.coveralls

--- a/test/app.js
+++ b/test/app.js
@@ -46,7 +46,7 @@ describe('node:app', function () {
         name: 'generator-node',
         description: 'A node generator',
         homepage: 'http://yeoman.io',
-        githubUsername: 'yeoman',
+        githubAccount: 'yeoman',
         authorName: 'The Yeoman Team',
         authorEmail: 'hi@yeoman.io',
         authorUrl: 'http://yeoman.io',
@@ -87,6 +87,16 @@ describe('node:app', function () {
         files: ['lib'],
         keywords: this.answers.keywords
       });
+    });
+
+    it('creates and fill contents in README.md', function () {
+      assert.file('README.md');
+      assert.fileContent('README.md', 'var generatorNode = require(\'generator-node\');');
+      assert.fileContent('README.md', '> A node generator');
+      assert.fileContent('README.md', '$ npm install --save generator-node');
+      assert.fileContent('README.md', '© [The Yeoman Team](http://yeoman.io)');
+      assert.fileContent('README.md', '[travis-image]: https://travis-ci.org/yeoman/generator-node.svg?branch=master');
+      assert.fileContent('README.md', 'coveralls');
     });
   });
 

--- a/test/readme.js
+++ b/test/readme.js
@@ -11,7 +11,7 @@ describe('node:readme', function () {
         description: 'a cool project',
         githubAccount: 'yeoman',
         authorName: 'Yeoman',
-        authorURL: 'http://yeoman.io',
+        authorUrl: 'http://yeoman.io',
         coveralls: true
       })
       .on('ready', function (gen) {
@@ -41,7 +41,7 @@ describe('node:readme --no-coveralls', function () {
         description: 'a cool project',
         githubAccount: 'yeoman',
         authorName: 'Yeoman',
-        authorURL: 'http://yeoman.io',
+        authorUrl: 'http://yeoman.io',
         coveralls: false
       })
       .on('ready', function (gen) {


### PR DESCRIPTION
In app/index.js, its `githubUsername` but in readme/index.js its `githubAccount`.
In app/index.js, its `authorUrl` but in readme/index.js its `authorURL`.
So the generated readme.md has parts missing.
Test is also added.