### PR TITLE
Fixed missing package name in generated cli.js

### DIFF
--- a/generators/cli/index.js
+++ b/generators/cli/index.js
@@ -21,7 +21,7 @@ module.exports = generators.Base.extend({
       this.fs.copyTpl(
         this.templatePath('cli.js'),
         this.destinationPath('lib/cli.js'), {
-          pkgSafeName: _.camelCase(this.options.name),
+          pkgSafeName: _.camelCase(this.appname),
           babel: this.options.babel
         }
       );

--- a/test/cli.js
+++ b/test/cli.js
@@ -15,6 +15,11 @@ describe('node:cli', function () {
     assert.fileContent('lib/cli.js', 'import meow from \'meow\'');
   });
 
+  it('Contains package name references', function() {
+    assert.noFileContent('lib/cli.js', 'var = require(\'./\');');
+    assert.noFileContent('lib/cli.js', 'import  from \'./\';');
+  });
+
   it('Extends package.json', function () {
     assert.fileContent('package.json', '"bin": "dist/cli.js"');
     assert.fileContent('package.json', '"meow"');


### PR DESCRIPTION
`this.options.name` was undefined since CLI generator doesn't have any `name` option specified.