### PR TITLE
Speed up TravisCI build

### DIFF
--- a/generators/travis/index.js
+++ b/generators/travis/index.js
@@ -3,9 +3,22 @@ var generators = require('yeoman-generator');
 
 module.exports = generators.Base.extend({
   initializing: function () {
-    this.fs.copy(
+
+    var shrink = this.fs.exists(this.destinationPath('npm-shrinkwrap.json'));
+
+    this.fs.copyTpl(
       this.templatePath('travis.yml'),
-      this.destinationPath('.travis.yml')
+      this.destinationPath('.travis.yml'), {
+        shrink: shrink
+      }
     );
+
+    if (shrink) {
+      this.fs.copy(
+        this.templatePath('travis-caching-dependencies.sh'),
+        this.destinationPath('scripts/travis-caching-dependencies.sh')
+      );
+    }
+
   }
 });

--- a/generators/travis/templates/travis-caching-dependencies.sh
+++ b/generators/travis/templates/travis-caching-dependencies.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+SHRINKWRAP_FILE=npm-shrinkwrap.json
+SHRINKWRAP_CACHED_FILE=node_modules/npm-shrinkwrap.cached.json
+
+if diff -q $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE; then
+  echo 'No shrinkwrap changes detected. NPM install will be skipped...';
+else
+  echo 'Blowing away node_modules and reinstalling NPM dependencies...'
+  rm -rf node_modules
+  npm install
+  cp $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE
+  echo 'NPM install successful!'
+fi

--- a/generators/travis/templates/travis.yml
+++ b/generators/travis/templates/travis.yml
@@ -4,3 +4,16 @@ node_js:
   - '0.10'
   - '0.12'
   - 'iojs'
+<% if (shrink) { %>
+cache:
+  directories:
+    - node_modules
+
+install:
+  # Check the size of caches
+  - du -sh ./node_modules || true
+  # Install last stable NPM
+  - npm install -g npm@latest
+  # Instal npm dependencies and ensure that npm cache is not stale
+  - ./scripts/travis-caching-dependencies.sh
+<% } -%>

--- a/test/travis.js
+++ b/test/travis.js
@@ -12,4 +12,33 @@ describe('node:travis', function () {
   it('creates .travis.yml', function () {
     assert.file('.travis.yml');
   });
+
+  it('fill .travis.yml', function () {
+    assert.fileContent('.travis.yml', 'sudo: false');
+    assert.fileContent('.travis.yml', 'language: node_js');
+    assert.fileContent('.travis.yml', /node_js:\s*- '0\.10'\s*- '0\.12'\s*- 'iojs'/);
+  });
+
+  describe('with existing npm-shrinkwrap.json', function () {
+    before(function (done) {
+      helpers.run(path.join(__dirname, '../generators/travis'))
+        .on('ready', function (generator) {
+          generator.fs.write(
+            generator.destinationPath('npm-shrinkwrap.json'),
+            '{"name": "my-lib", "version": "1.0.0", "dependencies": {}}'
+          );
+        })
+        .on('end', done);
+    });
+
+    it('fill .travis.yml for caching node_modules', function () {
+      assert.fileContent('.travis.yml', /cache:\s*directories:\s*- node_modules/);
+      assert.fileContent('.travis.yml', '- npm install -g npm@latest');
+      assert.fileContent('.travis.yml', '- ./scripts/travis-caching-dependencies.sh');
+    });
+
+    it('create scripts/travis-caching-dependencies.sh', function () {
+      assert.file('scripts/travis-caching-dependencies.sh');
+    });
+  });
 });


### PR DESCRIPTION
fix #154
* use cache directories for `node_modules`
* add script folder to manage cache and test workflow with npm-shrinkwrap

***

### Runs on container

Already activate by `sudo: false` in .travis.yml [doc](http://docs.travis-ci.com/user/migrating-from-legacy/#How-can-I-use-container-based-infrastructure%3F).

### Duration build

* Without cache: ~55sec https://travis-ci.org/zckrs/generator-node/jobs/73143671#L104
* With cache: ~25sec https://travis-ci.org/zckrs/generator-node/jobs/73144757#L103

### Shrinkwrap

I use `$ npm shrinkwrap --dev` to dave all dependencies generate JSON file [doc](https://docs.npmjs.com/cli/shrinkwrap).


 