### PR TITLE
remove sudo false

### DIFF
--- a/generators/travis/templates/travis.yml
+++ b/generators/travis/templates/travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: node_js
 node_js:
   - '0.10'


### PR DESCRIPTION
You no longer have to add `sudo:false` in .travis.yml to new repos to get the faster container-based infrastructure: http://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure