### PR TITLE
Clean dist folder of files before running babel

### DIFF
--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -70,6 +70,7 @@ module.exports = generators.Base.extend({
       }
 
       if (this.options.babel) {
+        prepublishTasks.push('clean');
         prepublishTasks.push('babel');
       }
 

--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -70,7 +70,6 @@ module.exports = generators.Base.extend({
       }
 
       if (this.options.babel) {
-        prepublishTasks.push('clean');
         prepublishTasks.push('babel');
       }
 

--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -53,6 +53,7 @@ module.exports = generators.Base.extend({
 
       if (this.options.babel) {
         pkg.devDependencies['gulp-babel'] = '^5.1.0';
+        pkg.devDependencies['del'] = '^2.0.2';
         pkg.devDependencies['babel-core'] = '^5.5.0';
         pkg.devDependencies.isparta = '^3.0.3';
       }

--- a/generators/gulp/templates/gulpfile.js
+++ b/generators/gulp/templates/gulpfile.js
@@ -79,7 +79,7 @@ gulp.task('babel', ['clean'], function () {
 });
 
 gulp.task('clean', function() {
-  return del('dist/**/*');
+  return del('dist');
 });
 <% } -%>
 

--- a/generators/gulp/templates/gulpfile.js
+++ b/generators/gulp/templates/gulpfile.js
@@ -72,7 +72,7 @@ gulp.task('coveralls', ['test'], function () {
 <% } -%>
 <% if (babel) { -%>
 
-gulp.task('babel', function () {
+gulp.task('babel', ['clean'], function () {
   return gulp.src('<%- projectRoot %>')
     .pipe(babel())
     .pipe(gulp.dest('dist'));

--- a/generators/gulp/templates/gulpfile.js
+++ b/generators/gulp/templates/gulpfile.js
@@ -14,6 +14,7 @@ var coveralls = require('gulp-coveralls');
 <% } -%>
 <% if (babel) { -%>
 var babel = require('gulp-babel');
+var del = require('del');
 var isparta = require('isparta');
 
 // Initialize the babel transpiler so ES2015 files gets compiled
@@ -72,6 +73,8 @@ gulp.task('coveralls', ['test'], function () {
 <% if (babel) { -%>
 
 gulp.task('babel', function () {
+  del(['dist/**/*']);
+
   return gulp.src('<%- projectRoot %>')
     .pipe(babel())
     .pipe(gulp.dest('dist'));

--- a/generators/gulp/templates/gulpfile.js
+++ b/generators/gulp/templates/gulpfile.js
@@ -78,7 +78,7 @@ gulp.task('babel', ['clean'], function () {
     .pipe(gulp.dest('dist'));
 });
 
-gulp.task('clean', function() {
+gulp.task('clean', function () {
   return del('dist');
 });
 <% } -%>

--- a/generators/gulp/templates/gulpfile.js
+++ b/generators/gulp/templates/gulpfile.js
@@ -73,11 +73,13 @@ gulp.task('coveralls', ['test'], function () {
 <% if (babel) { -%>
 
 gulp.task('babel', function () {
-  del(['dist/**/*']);
-
   return gulp.src('<%- projectRoot %>')
     .pipe(babel())
     .pipe(gulp.dest('dist'));
+});
+
+gulp.task('clean', function() {
+  return del('dist/**/*');
 });
 <% } -%>
 

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -80,7 +80,7 @@ describe('node:gulp', function () {
 
     it('includes babel configuration', function () {
       assert.fileContent('gulpfile.js', 'gulp.task(\'babel\'');
-      assert.fileContent('gulpfile.js', 'gulp.task(\'prepublish\', [\'nsp\', \'babel\']);');
+      assert.fileContent('gulpfile.js', 'gulp.task(\'prepublish\', [\'nsp\', \'clean\', \'babel\']);');
       assert.fileContent('package.json', 'gulp-babel');
       assert.fileContent('.gitignore', 'dist');
     });

--- a/test/gulp.js
+++ b/test/gulp.js
@@ -80,7 +80,7 @@ describe('node:gulp', function () {
 
     it('includes babel configuration', function () {
       assert.fileContent('gulpfile.js', 'gulp.task(\'babel\'');
-      assert.fileContent('gulpfile.js', 'gulp.task(\'prepublish\', [\'nsp\', \'clean\', \'babel\']);');
+      assert.fileContent('gulpfile.js', 'gulp.task(\'prepublish\', [\'nsp\', \'babel\']);');
       assert.fileContent('package.json', 'gulp-babel');
       assert.fileContent('.gitignore', 'dist');
     });


### PR DESCRIPTION
This fixes the issue found in #173 by cleaning the dist folder before prepublishing using the 'del' module, as recommended by: https://github.com/gulpjs/gulp/blob/master/docs/recipes/delete-files-folder.md