### PR TITLE
* generators/git: added repoBaseUrl to pass another repository server

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -221,7 +221,7 @@ module.exports = generators.Base.extend({
     this.composeWith('node:git', {
       options: {
         name: this.props.name,
-        githubAccount: this.props.githubAccount
+        account: this.props.githubAccount
       }
     }, {
       local: require.resolve('../git')

--- a/generators/git/index.js
+++ b/generators/git/index.js
@@ -13,16 +13,23 @@ module.exports = generators.Base.extend({
       desc: 'Relocate the location of the generated files.'
     });
 
+    this.option('repoBaseUrl', {
+      type: String,
+      required: false,
+      defaults: 'git@github.com:',
+      desc: 'Base url of the git repository'
+    });
+
     this.option('name', {
       type: String,
       required: true,
       desc: 'Module name'
     });
 
-    this.option('github-account', {
+    this.option('account', {
       type: String,
       required: true,
-      desc: 'GitHub username or organization'
+      desc: 'Username or organization (probably Github)'
     });
   },
 
@@ -53,7 +60,7 @@ module.exports = generators.Base.extend({
     if (this.originUrl) {
       repository = this.originUrl;
     } else {
-      repository = this.options.githubAccount + '/' + this.options.name;
+      repository = this.options.account + '/' + this.options.name;
     }
 
     this.pkg.repository = this.pkg.repository || repository;
@@ -69,7 +76,7 @@ module.exports = generators.Base.extend({
     if (!this.originUrl) {
       var repoSSH = this.pkg.repository;
       if (this.pkg.repository.indexOf('.git') === -1) {
-        repoSSH = 'git@github.com:' + this.pkg.repository + '.git';
+        repoSSH = this.options.repoBaseUrl + this.pkg.repository + '.git';
       }
       this.spawnCommandSync('git', ['remote', 'add', 'origin', repoSSH], {
         cwd: this.destinationPath(this.options.generateInto)

--- a/test/git.js
+++ b/test/git.js
@@ -7,7 +7,9 @@ describe('node:git', function () {
   before(function (done) {
     helpers.run(path.join(__dirname, '../generators/git'))
       .withOptions({
-        repositoryPath: 'yeoman/generator-node'
+        repositoryPath: 'yeoman/generator-node',
+        account: 'dummyOrg',
+        name: 'dummyProject'
       })
       .on('end', done);
   });
@@ -23,6 +25,10 @@ describe('node:git', function () {
   it('initialize git repository', function () {
     assert.file('.git');
   });
+
+  it('.git/config has the correct repo base url', function () {
+    assert.fileContent('.git/config', /url = git@github\.com:dummyOrg\/dummyProject\.git/);
+  });
 });
 
 describe('node:git', function () {
@@ -30,6 +36,8 @@ describe('node:git', function () {
     helpers.run(path.join(__dirname, '../generators/git'))
       .withOptions({
         repositoryPath: 'yeoman/generator-node',
+        account: 'dummyOrg',
+        name: 'dummyProject',
         generateInto: 'other/'
       })
       .on('end', done);
@@ -45,5 +53,22 @@ describe('node:git', function () {
 
   it('initialize git repository with generate-into option', function () {
     assert.file('other/.git');
+  });
+});
+
+describe('node:git with a dummy git server url', function () {
+  before(function (done) {
+    helpers.run(path.join(__dirname, '../generators/git'))
+      .withOptions({
+        repositoryPath: 'yeoman/generator-node',
+        repoBaseUrl: 'ssh://git@dummy.xyz/',
+        account: 'dummyOrg',
+        name: 'dummyProject'
+      })
+      .on('end', done);
+  });
+
+  it('.git/config has the correct repo base url', function () {
+    assert.fileContent('.git/config', /url = ssh:\/\/git@dummy\.xyz\/dummyOrg\/dummyProject\.git/);
   });
 });


### PR DESCRIPTION
* replaced githubAccount option name by account

Here is the scenario I found this option crucial: the generated app has to be stored in another git server than github.