### PR TITLE
Dont warn on mockery replace. -> quieter tests

### DIFF
--- a/test/app.js
+++ b/test/app.js
@@ -7,7 +7,10 @@ var helpers = require('yeoman-generator').test;
 
 describe('node:app', function () {
   before(function () {
-    mockery.enable({warnOnUnregistered: false});
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false
+    });
 
     mockery.registerMock('npm-name', function (name, cb) {
       cb(null, true);


### PR DESCRIPTION
```
  node:app
    running on existing project
Initialized empty Git repository in /private/var/folders/28/tsd1nk357hsfh5kb8r2dq0vm0000gn/T/18d07f1c22c1eec84bd854e465591b3596f41176/.git/
      ✓ extends package.json keys with missing ones

  1 passing (237ms)
```

vs

```
  node:app
WARNING: Replacing existing mock for module: npm-name
WARNING: Replacing existing mock for module: github-username
WARNING: Replacing existing mock for module: /Users/eddie/Sites/OSS/yeoman/generator-node/node_modules/generator-license/app/index.js
    running on existing project
Initialized empty Git repository in /private/var/folders/28/tsd1nk357hsfh5kb8r2dq0vm0000gn/T/957e7d0747e8c4d36793ab618ceb83d16af3b411/.git/
      ✓ extends package.json keys with missing ones

  1 passing (237ms)
```