### PR TITLE
fix keywords in the prompt

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -150,7 +150,9 @@ module.exports = generators.Base.extend({
         name: 'keywords',
         message: 'Package keywords (comma to split)',
         when: !this.pkg.keywords,
-        filter: _.words
+        filter: function (words) {
+          return words.split(/\s*,\s*/g);
+        }
       }, {
         name: 'babel',
         type: 'confirm',


### PR DESCRIPTION
Keywords weren't being handled correctly in the prompts. Typing in `foo,bar, ad3pt  ,  yeoman-generator, something else` was producing this as the keywords:

```
  "keywords": [
    "foo",
    "bar",
    "ad",
    "3",
    "pt",
    "yeoman",
    "generator",
    "something",
    "else"
  ],
```

instead of

```
  "keywords": [
    "foo",
    "bar",
    "ad3pt",
    "yeoman-generator",
    "something else"
  ],
```

Couldn't figure out a way to write a test for this since `helpers.run().withPrompts` skips the prompt's filter.