### PR TITLE
Include keywords from existing package.json

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -193,7 +193,8 @@ module.exports = generators.Base.extend({
   writing: function () {
     // Re-read the content at this point because a composed generator might modify it.
     var currentPkg = this.fs.readJSON(this.destinationPath('package.json'), {});
-    var pkg = {
+
+    var pkg = extend({
       name: _.kebabCase(this.props.name),
       version: '0.0.0',
       description: this.props.description,
@@ -210,11 +211,16 @@ module.exports = generators.Base.extend({
         this.options.projectRoot,
         'index.js'
       ),
-      keywords: this.props.keywords
-    };
+      keywords: []
+    }, currentPkg);
+
+    // Combine the keywords
+    if (this.props.keywords) {
+      pkg.keywords = _.uniq(this.props.keywords.concat(pkg.keywords));
+    }
 
     // Let's extend package.json so we're not overwriting user previous fields
-    this.fs.writeJSON('package.json', extend(pkg, currentPkg));
+    this.fs.writeJSON(this.destinationPath('package.json'), pkg);
   },
 
   default: function () {


### PR DESCRIPTION
If a package.json has keywords already, this adds the keywords from prompts on to them

Fixes yeoman/generator-generator#135
Fixes yeoman/generator-generator#129


Maybe not the best solution but it does get them in there. If a previous generator schedules them to write, I think that happens after the composeWith initialize queue so the reading of the package.json doesn't have them yet. Maybe they should be passed ...