### PR TITLE
Re-add skip license creation in extended generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ Remember you can see the options of each sub generators by running `yo node:sub 
 - `node:eslint`
 - `node:git`
 - `node:gulp`
-- `node:license`
 - `node:readme`
 
 ## Sponsors

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -51,6 +51,13 @@ module.exports = generators.Base.extend({
       desc: 'Include or not a gulpfile.js'
     });
 
+    this.option('license', {
+      type: Boolean,
+      required: false,
+      defaults: true,
+      desc: 'Include a license'
+    });
+
     this.option('name', {
       type: String,
       required: false,
@@ -285,7 +292,7 @@ module.exports = generators.Base.extend({
       });
     }
 
-    if (!this.pkg.license) {
+    if (this.options.license && !this.pkg.license) {
       this.composeWith('license', {
         options: {
           name: this.props.authorName,


### PR DESCRIPTION
This code will re-add the option to skip license creation.
My reasoning is that `license:app` doesn't meet my company's needs. The rest of `node:app` meets my needs, or has options to turn off what I don't want/need. 

I also altered the documentation because stating that there is a `node:license` but not having a `generators/license` seems like an oversight since `node:license` was outsourced to `license:app`.