### PR TITLE
Fix errors caused on Windows due to path.join

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -221,7 +221,7 @@ module.exports = generators.Base.extend({
       main: this.props.babel ? 'dist/index.js' : path.join(
         this.options.projectRoot,
         'index.js'
-      ),
+      ).replace(/\\/g, '/'),
       keywords: []
     }, currentPkg);
 

--- a/generators/gulp/index.js
+++ b/generators/gulp/index.js
@@ -105,7 +105,7 @@ module.exports = generators.Base.extend({
           babel: this.options.babel,
           tasks: stringifyArray(tasks),
           prepublishTasks: stringifyArray(prepublishTasks),
-          projectRoot: path.join(this.options.projectRoot, '**/*.js')
+          projectRoot: path.join(this.options.projectRoot, '**/*.js').replace(/\\/g, '/')
         }
       );
     },


### PR DESCRIPTION
On Windows there are some tests that fail and some of the generated code is wrong due to path.join converting forward slashes to backslashes on Windows.

For example (from the generator's test suite): 

```
  1) node:app --no-babel include the raw files:

      AssertionError: 'lib\\index.js' == 'lib/index.js'
      + expected - actual

      -lib\index.js
      +lib/index.js
```
And (from the generated gulpfile). Note the backslashes in the path:

```js
gulp.task('pre-test', function () {
  return gulp.src('lib\**\*.js')
    .pipe(excludeGitignore())
    .pipe(istanbul({
      includeUntested: true,
      instrumenter: isparta.Instrumenter
    }))
    .pipe(istanbul.hookRequire());
});
```
