### PR TITLE
Bring back line ending correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ module.exports = class extends Generator({
 Here's a list of our supported options:
 
 - `boilerplate` (Boolean, default true) include or not the boilerplate files (`lib/index.js`, `test/index.js`).
-- `cli` (Boolean, default false) include or not a `lib/cli.js` file.
+- `cli` (Boolean, default false) include or not a `lib/cli.js` file and add an additional npm script to correct line endings.
 - `editorconfig` (Boolean, default true) include or not a `.editorconfig` file.
 - `git` (Boolean, default true) include or not the git files (`.gitattributes`, `.gitignore`).
 - `license` (Boolean, default true) include or not a `LICENSE` file.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ module.exports = class extends Generator({
 Here's a list of our supported options:
 
 - `boilerplate` (Boolean, default true) include or not the boilerplate files (`lib/index.js`, `test/index.js`).
-- `cli` (Boolean, default false) include or not a `lib/cli.js` file and add an additional npm script to correct line endings.
+- `cli` (Boolean, default false) include or not a `lib/cli.js` file.
 - `editorconfig` (Boolean, default true) include or not a `.editorconfig` file.
 - `git` (Boolean, default true) include or not the git files (`.gitattributes`, `.gitignore`).
 - `license` (Boolean, default true) include or not a `LICENSE` file.

--- a/__tests__/cli.js
+++ b/__tests__/cli.js
@@ -24,7 +24,7 @@ describe('node:cli', function () {
     assert.fileContent('package.json', '"bin": "lib/cli.js"');
     assert.fileContent('package.json', '"meow"');
     assert.fileContent('package.json', /"lec": "\^/);
-    assert.fileContent('package.json', '"fixLineEndings": "lec lib/cli.js -c LF"');
+    assert.fileContent('package.json', '"prepublish": "lec lib/cli.js -c LF && nsp check"');
   });
 });
 

--- a/__tests__/cli.js
+++ b/__tests__/cli.js
@@ -23,6 +23,8 @@ describe('node:cli', function () {
   it('Extends package.json', function () {
     assert.fileContent('package.json', '"bin": "lib/cli.js"');
     assert.fileContent('package.json', '"meow"');
+    assert.fileContent('package.json', /"lec": "\^/);
+    assert.fileContent('package.json', '"fixLineEndings": "lec lib/cli.js -c LF"');
   });
 });
 

--- a/generators/cli/index.js
+++ b/generators/cli/index.js
@@ -28,7 +28,7 @@ module.exports = Generator.extend({
           lec: '^1.0.1'
         },
         scripts: {
-          fixLineEndings: 'lec lib/cli.js -c LF'
+          prepublish: 'lec lib/cli.js -c LF && nsp check'
         }
       });
 

--- a/generators/cli/index.js
+++ b/generators/cli/index.js
@@ -23,6 +23,12 @@ module.exports = Generator.extend({
         bin: 'lib/cli.js',
         dependencies: {
           meow: '^3.7.0'
+        },
+        devDependencies: {
+          lec: '^1.0.1'
+        },
+        scripts: {
+          fixLineEndings: 'lec lib/cli.js -c LF'
         }
       });
 


### PR DESCRIPTION
Relates to #257, #251

Must say that I’m not sure if I’m super happy with that because using the line ending corrector was a no brainer before. It was bundled into the gulp default task as well as the watch task.

So I’m asking what to do about it.
Ideas: 
- Document that with more details in the README?
  - I guess people won’t read this 😕 
- Add an additional npm script like `build `?
  - So the scripts section could look like:
    ```
    "scripts": {
        "prepublish": "nsp check",
        "pretest": "eslint **/*.js --fix",
        "test": "jest",
        "fixLineEndings": "lec lib/cli.js"
        "build": "npm run fixLineEndings && npm test"
    }
     ```

Any feedback appreciated 😗 