### PR TITLE
Generate .eslintignore file in eslint subgenerator

### DIFF
--- a/__tests__/eslint.js
+++ b/__tests__/eslint.js
@@ -15,9 +15,10 @@ describe('node:eslint', () => {
             }
           },
           scripts: {
-            pretest: 'eslint . --ignore-path .gitignore --fix'
+            pretest: 'eslint . --fix'
           }
         });
+        assert.file('.eslintignore');
       });
   });
 
@@ -31,6 +32,7 @@ describe('node:eslint', () => {
             extends: 'xo-space'
           }
         });
+        assert.file('other/.eslintignore');
       });
   });
 });

--- a/generators/eslint/index.js
+++ b/generators/eslint/index.js
@@ -28,13 +28,18 @@ module.exports = class extends Generator {
         }
       },
       scripts: {
-        pretest: 'eslint . --ignore-path .gitignore --fix'
+        pretest: 'eslint . --fix'
       }
     };
 
     this.fs.extendJSON(
       this.destinationPath(this.options.generateInto, 'package.json'),
       pkgJson
+    );
+
+    this.fs.copy(
+      this.templatePath('eslintignore'),
+      this.destinationPath(this.options.generateInto, '.eslintignore')
     );
   }
 };

--- a/generators/eslint/templates/eslintignore
+++ b/generators/eslint/templates/eslintignore
@@ -1,0 +1,1 @@
+coverage


### PR DESCRIPTION
And remove `--ignore-path` option in ESLint npm script
Fixes #263