### PR TITLE
Allow the generator to be used behind a proxy

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -8,7 +8,7 @@ const path = require('path');
 const askName = require('inquirer-npm-name');
 const chalk = require('chalk');
 const pkgJson = require('../../package.json');
-require('global-tunnel').initialize();
+require('global-tunnel-ng').initialize();
 
 module.exports = class extends Generator {
   constructor(args, options) {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -8,7 +8,7 @@ const path = require('path');
 const askName = require('inquirer-npm-name');
 const chalk = require('chalk');
 const pkgJson = require('../../package.json');
-require('caw-global');
+require('global-tunnel').initialize();
 
 module.exports = class extends Generator {
   constructor(args, options) {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -8,6 +8,7 @@ const path = require('path');
 const askName = require('inquirer-npm-name');
 const chalk = require('chalk');
 const pkgJson = require('../../package.json');
+require('caw-global');
 
 module.exports = class extends Generator {
   constructor(args, options) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "generator-travis": "^1.5.3",
     "git-remote-origin-url": "^2.0.0",
     "github-username": "^4.1.0",
-    "global-tunnel": "^1.2.0",
+    "global-tunnel-ng": "^2.1.1",
     "inquirer-npm-name": "^2.0.0",
     "lodash": "^4.17.4",
     "parse-author": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
-    "caw-global": "^1.0.0-2",
     "chalk": "^2.2.0",
     "generator-jest": "^1.4.2",
     "generator-license": "^5.2.0",
     "generator-travis": "^1.5.3",
     "git-remote-origin-url": "^2.0.0",
     "github-username": "^4.1.0",
+    "global-tunnel": "^1.2.0",
     "inquirer-npm-name": "^2.0.0",
     "lodash": "^4.17.4",
     "parse-author": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
+    "caw-global": "^1.0.0-0",
     "chalk": "^2.2.0",
     "generator-jest": "^1.4.2",
     "generator-license": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
-    "caw-global": "^1.0.0-0",
+    "caw-global": "^1.0.0-2",
     "chalk": "^2.2.0",
     "generator-jest": "^1.4.2",
     "generator-license": "^5.2.0",


### PR DESCRIPTION
Included [global-tunnel-ng](https://github.com/np-maintain/global-tunnel) that overrides Node's [ Agent](https://nodejs.org/api/http.html#http_class_http_agent) with an Agent capable of tunneling through a proxy. Because `global-tunnel` is initialized with no parameters, the Agent will be overwritten only if a proxy is configured in the widely used environment variables `http_proxy` and `https_proxy`, so this should have no effect for users who are not explicitly using a proxy.

The most common use case is to set these variables at a `.bashrc` or `.zshrc` file, to have them on every shell session

```bash
export http_proxy="http://www.proxy.com"
```

Fixes #274 
