### PR TITLE
downgrading husky 2.6.0 and add eslintrc.js

### DIFF
--- a/generators/eslint/index.js
+++ b/generators/eslint/index.js
@@ -43,5 +43,9 @@ module.exports = class extends Generator {
       this.templatePath('eslintignore'),
       this.destinationPath(this.options.generateInto, '.eslintignore')
     );
+    this.fs.copy(
+      this.templatePath('.eslintrc.js'),
+      this.destinationPath(this.options.generateInto, '.eslintrc.js')
+    );
   }
 };

--- a/generators/eslint/templates/.eslintrc.js
+++ b/generators/eslint/templates/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    "extends": [
+      "prettier"
+    ],
+    'env': {
+        'es6': true,
+        'node': true
+    },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5134,45 +5134,76 @@
       }
     },
     "husky": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.9.tgz",
-      "integrity": "sha512-Yolhupm7le2/MqC1VYLk/cNmYxsSsqKkTyBhzQHhPK1jFnC89mmmNVuGtLNabjDI6Aj8UNIr0KpRNuBkiC4+sg==",
+      "version": "2.7.0",
+      "resolved": "http://r.cnpmjs.org/husky/download/husky-2.7.0.tgz",
+      "integrity": "sha1-wKmmo7URRiJOEbugtGu6VG5GHQU=",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2",
-        "ci-info": "^2.0.0",
-        "cosmiconfig": "^5.2.1",
+        "cosmiconfig": "^5.2.0",
         "execa": "^1.0.0",
+        "find-up": "^3.0.0",
         "get-stdin": "^7.0.0",
-        "opencollective-postinstall": "^2.0.2",
-        "pkg-dir": "^4.2.0",
-        "please-upgrade-node": "^3.2.0",
-        "read-pkg": "^5.2.0",
+        "is-ci": "^2.0.0",
+        "pkg-dir": "^4.1.0",
+        "please-upgrade-node": "^3.1.1",
+        "read-pkg": "^5.1.1",
         "run-node": "^1.0.0",
         "slash": "^3.0.0"
       },
       "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "http://r.cnpmjs.org/find-up/download/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "locate-path": "^3.0.0"
           }
         },
         "get-stdin": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
-          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+          "resolved": "http://r.cnpmjs.org/get-stdin/download/get-stdin-7.0.0.tgz",
+          "integrity": "sha1-jV3pjxUXGhJcXlFmQ8em0OqKlvY=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "http://r.cnpmjs.org/locate-path/download/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.2",
+          "resolved": "http://r.cnpmjs.org/p-limit/download/p-limit-2.2.2.tgz",
+          "integrity": "sha1-YSebZ3IfUoeqHBOpp/u8SMkpGx4=",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "http://r.cnpmjs.org/p-locate/download/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "http://r.cnpmjs.org/p-try/download/p-try-2.2.0.tgz",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "slash": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "resolved": "http://r.cnpmjs.org/slash/download/slash-3.0.0.tgz",
+          "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
           "dev": true
         }
       }
@@ -8011,12 +8042,6 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "opencollective-postinstall": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
-      "dev": true
-    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -8259,8 +8284,8 @@
     },
     "pkg-dir": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "resolved": "http://r.cnpmjs.org/pkg-dir/download/pkg-dir-4.2.0.tgz",
+      "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
@@ -8268,8 +8293,8 @@
       "dependencies": {
         "find-up": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "resolved": "http://r.cnpmjs.org/find-up/download/find-up-4.1.0.tgz",
+          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
@@ -8278,17 +8303,17 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "resolved": "http://r.cnpmjs.org/locate-path/download/locate-path-5.0.0.tgz",
+          "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
         },
         "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+          "version": "2.2.2",
+          "resolved": "http://r.cnpmjs.org/p-limit/download/p-limit-2.2.2.tgz",
+          "integrity": "sha1-YSebZ3IfUoeqHBOpp/u8SMkpGx4=",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -8296,8 +8321,8 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "resolved": "http://r.cnpmjs.org/p-locate/download/p-locate-4.1.0.tgz",
+          "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
@@ -8305,14 +8330,14 @@
         },
         "p-try": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "resolved": "http://r.cnpmjs.org/p-try/download/p-try-2.2.0.tgz",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
           "dev": true
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "resolved": "http://r.cnpmjs.org/path-exists/download/path-exists-4.0.0.tgz",
+          "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
           "dev": true
         }
       }
@@ -8810,8 +8835,8 @@
     },
     "run-node": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
-      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+      "resolved": "http://r.cnpmjs.org/run-node/download/run-node-1.0.0.tgz",
+      "integrity": "sha1-RrULlGoqotSUeuHYhumFb9nKvl4=",
       "dev": true
     },
     "run-parallel": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-config-prettier": "^6.6.0",
     "eslint-config-xo": "^0.27.2",
     "eslint-plugin-prettier": "^3.1.1",
-    "husky": "^3.0.9",
+    "husky": "^2.6.0",
     "jest": "^24.9.0",
     "lint-staged": "^9.4.3",
     "prettier": "^1.19.1",


### PR DESCRIPTION
https://github.com/typicode/husky/blob/master/src/installer/gitRevParse.ts#L9
https://github.com/typicode/husky/issues/580

add eslintrc.js so the brand new package can pass `npm run test`
